### PR TITLE
feat: add narration_script.md

### DIFF
--- a/part2/narration_script.md
+++ b/part2/narration_script.md
@@ -1,0 +1,53 @@
+# Singular Value Decomposition — Extending the Perspective
+
+Every linear transformation, no matter how complex, is secretly just a few simple moves in disguise. Up to this point, we’ve spent a lot of time uncovering those moves looking for the "special" directions, those vectors that don't get knocked off their span, which we called eigenvectors. We saw how, if a matrix is nice enough to have a full set of them, we can "diagonalize" it. This effectively lets us view a complex, shearing transformation as a simple, independent scaling along different axes. It’s a powerful way to peel back the layers of a transformation and see the small number of elementary moves hiding underneath.
+
+But there’s a catch that often goes unaddressed: diagonalization is incredibly picky. It only works for square matrices, and even then, not all square matrices are diagonalizable. Some matrices simply don't have enough eigenvectors to form a basis. This leaves us with a nagging question: Is there a way to find a "simple" diagonal version of _any_ linear transformation, regardless of its shape or whether it "behaves" nicely?
+
+This is where the **Singular Value Decomposition**, or SVD, enters the stage. If diagonalization is a specialized tool for a specific class of problems, SVD is the master key. It allows us to take any transformation—rectangular, singular, or otherwise—and break it down into three simple, intuitive steps.
+
+## The Geometry of SVD
+
+To understand what SVD is actually doing, let’s think about how a linear transformation affects the space it lives in. Imagine a unit circle in a 2D input space. When we apply a linear transformation $A$ to this space, that circle usually gets stretched and tilted into an ellipse in the output space.
+
+The core insight of SVD is this: No matter how mangled or distorted that ellipse looks, we can always find a set of perpendicular (orthonormal) vectors in our input space that land exactly on the axes of that ellipse in the output space.
+
+In the language of matrices, we describe this process as a sequence of three distinct motions: $A = U \Sigma V^T$.
+
+1. **$V^T$ (Rotation in the input space):** We first rotate our coordinate system so that our basis vectors align with the directions that will eventually become the axes of our ellipse. Visually, the unit circle spins but doesn't look any different.
+2. **$\Sigma$ (Scaling):** We scale these vectors. The factors by which we stretch or squish them are called the **singular values**. Now the circle deforms into an ellipse, given the vectors have different lengths. If a singular value is zero, as in a vector has zero length, it means that entire dimension is collapsed, which is exactly what happens when a matrix is not "full rank." In other words, the number of nonzero singular values _is_ the rank of the matrix.
+3. **$U$ (Rotation in the output space):** Finally, we rotate the scaled vectors into their final orientation in the output space. The "unit ellipse" tilts into place as well.
+
+Notice the elegance here. While diagonalization tries to force the input and output to use the same "special" basis, SVD is more flexible. It allows the input basis ($V$) and the output basis ($U$) to be different, provided they are both orthonormal. This flexibility is exactly why SVD works for every single matrix in existence.
+
+If you're curious about how we actually find these $U$ and $V$ matrices, it involves looking at the matrices $A^T A$ and $AA^T$. Why them specifically? Because they're always symmetric, and symmetric matrices always diagonalize cleanly with orthogonal eigenvectors — that's the guarantee we need. Also, from a programming standpoint, finding these eigenvalues means solving a polynomial equation of degree $n$, and for $n$ of 5 or higher there is no closed-form solution — so if we were to implement SVD in Python, we have to use an iterative algorithm that converges toward the answer rather than computing it exactly.
+
+## SVD vs. Diagonalization
+
+It’s natural to wonder how this relates to the diagonalization process. You can think of diagonalization ($A = PDP^{-1}$) as a search for "fixed" directions. We want to find a basis where the input and output are the same, such that the transformation is just a scalar multiple.
+
+[Image comparing $A = PDP^{-1}$ and $A = U \Sigma V^T$, showing that diagonalization uses one basis while SVD uses two different orthogonal bases]
+
+The problem is that for many transformations, such "fixed" directions don't exist in a way that captures the whole transformation. A rotation matrix, for instance, has no real eigenvectors because every vector is moved off its span. However, SVD doesn't care if the vectors stay on their span. It only cares that we can find a perpendicular set of vectors that ends up as another perpendicular set of vectors, just potentially rotated and scaled.
+
+There is a beautiful bridge between the two: if you have a symmetric matrix—one that is equal to its own transpose—the SVD and diagonalization actually become the same thing. In that specific case, the singular values are just the absolute values of the eigenvalues. At the same time, the input and output rotations happen to be the same rotation, so U and V collapse into one matrix. But for the rest of the mathematical world, SVD provides a clarity that diagonalization cannot, especially when dealing with "tall" or "wide" matrices that map between spaces of different dimensions.
+
+## The Power of SVD in the Real World
+
+Because the SVD isolates the most important directions of a transformation (the largest singular values), it acts as a perfect filter for information. This is the secret sauce behind many technologies we use daily.
+
+Take **image compression**. Think of a high-resolution photograph. To a computer, that's just a massive matrix of color values. But not every pixel is equally important. By performing an SVD on that matrix, we can isolate the largest singular values. If we throw away the thousands of tiny singular values,we can reconstruct an image that looks almost identical to the original but requires a fraction of the data. We are essentially telling the computer, "Ignore the noise and the tiny details; just give me the primary structural components"—the big and broad shapes, the lighting, and the edges of the image.
+
+Beyond images, SVD is the engine behind **Principal Component Analysis**, or PCA — one of the most widely used tools in data science. Imagine you have a dataset of a thousand people, each described by dozens of measurements: height, weight, age, income, and so on. That's a cloud of points living in a very high-dimensional space, which is impossible to visualize directly. PCA uses SVD to find the directions along which your data varies the most — the axes of greatest spread. By projecting everything onto just the top two or three of these directions, you can collapse that high-dimensional cloud into something you can actually plot and reason about, while preserving as much of the structure as possible. Notice, the principal components are exactly the axes of the ellipse that your data cloud forms in high-dimensional space. SVD finds them the same way it always does — by identifying the directions that matter most. The dimensions it keeps are the ones with the largest singular values; the ones it discards are the noise.
+
+The same logic powers recommendation systems. When a streaming service decomposes a massive matrix of user ratings, the "latent factors" SVD uncovers are essentially the principal components of human taste — the hidden axes along which viewers actually differ from one another.
+
+Perhaps the most counterintuitive application is in the human language itself, fabulously called **Latent Semantic Analysis**. What SVD tries to do here is uncover the hidden relationships between words and the concepts they represent.
+
+In linguistics, we often deal with a "Term-Document Matrix," where every row is a unique word and every column is a specific document. The entries represent how many times a word appears in a text. The problem with these matrices is that they are incredibly messy. Language is full of synonyms (different words with the same meaning) and polysemy (the same word with different meanings), creating a "noisy" space where the computer sees two documents as unrelated just because they use different vocabulary to describe the same topic.
+
+By applying SVD to this matrix, we perform a sort of linguistic "compression". SVD first identifies "latent" (hidden) dimensions. Instead of seeing words as isolated units, it groups them into clusters based on where they appear. If "marathon" and "sprint" frequently appear in the same documents, SVD maps them to the same underlying concept of "Running." Then, by keeping only the top k singular values, we effectively "smooth" the data. This ignores the minor, accidental word choices of an author and focuses on the primary semantic structure. We can now compare documents not by whether they share the exact same words, but by whether they share the same conceptual "space."
+
+This allows a search engine to understand that a query for "feline" should return documents about "cats," even if the word "feline" never appears in the text. SVD transforms the chaotic, high-dimensional world of human language into a structured, geometric landscape where meaning is defined by proximity rather than just spelling.
+
+It’s a profound thought: The same geometric principle that describes how a circle turns into an ellipse is the same principle that allows a computer to understand the underlying structure of human preferences or the essence of a digital photograph.


### PR DESCRIPTION
## Linked issue

Closes #23 

## What this PR does

This PR adds the narration script for all three scenes with about 1500-1600 words aimed at 10-15 minute runtime. Note that this script only has narration, audio, visual and animation cues for the animator will be added in another PR.

## Checklist

### Code
- [x] All acceptance criteria on the linked issue are checked off
- [x] No `numpy.linalg`, `scipy.linalg`, or `sympy` solver calls in implementation code
- [x] All file paths use `pathlib.Path`, no hardcoded OS separators
- [x] No commented-out code committed
- [x] No debugging `print()` statements left in

### Tests
- [ ] At least 5 test cases per new function
- [ ] Edge cases covered (singular matrix, zero input, identity, etc.)
- [ ] All tests pass without errors

### Notebooks (if applicable)
- [ ] All cells run top-to-bottom without errors
- [ ] Output cells are visible — outputs not cleared before committing

### Report (SM only — sprint-end export PRs)
- [ ] `report.tex` exported from Prism and committed to `report/`
- [ ] `report.pdf` compiled and committed to `report/`
- [ ] No placeholder text remaining in exported sections

## Notes for reviewer
