### PR TITLE
feat: improve CI performance through pip caching and step consolidation

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+extend-ignore = E203

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,72 +1,3 @@
-# .github/workflows/ci.yml
-#
-# Runs on every pull request opened against dev or main.
-# Checks Python syntax and lints with flake8.
-# Manim is intentionally excluded — see note at bottom of file.
-#
-# ── YAML GOTCHAS ──────────────────────────────────────────────────────────────
-#
-# 1. INDENTATION IS EVERYTHING
-#    YAML uses spaces only — never tabs. Two spaces per level, consistently.
-#    A single tab character anywhere in this file will break the entire workflow
-#    with a cryptic parse error. If something mysteriously fails, check tabs first.
-#
-#    Correct:
-#      jobs:
-#        check:           ← 2 spaces
-#          runs-on: ...   ← 4 spaces
-#
-#    Wrong (tab characters):
-#      jobs:
-#          check:           ← tab, looks fine in some editors, breaks GitHub
-#
-# 2. COLONS INSIDE STRINGS MUST BE QUOTED
-#    Bare colons confuse the YAML parser into thinking a new key is starting.
-#
-#    Wrong:  run: echo hello: world
-#    Right:  run: echo "hello: world"
-#
-# 3. MULTILINE run: BLOCKS USE THE PIPE CHARACTER
-#    The | character means "treat everything indented below as a single string,
-#    preserving newlines." Each command goes on its own line.
-#
-#    Correct:
-#      run: |
-#        pip install numpy
-#        pip install flake8
-#
-#    Wrong (everything on one line with &&):
-#      run: pip install numpy && pip install flake8  ← works but unreadable
-#
-# 4. ACTION VERSIONS MUST BE PINNED
-#    actions/checkout@v4 is pinned to major version 4. Do not use @main or @master
-#    (unpinned) — those float to whatever the latest commit is and can break
-#    without warning. If GitHub logs show "Unable to find action", the version
-#    tag may have been deprecated — update to the current major version.
-#
-# 5. THE WORKFLOW FILE PATH IS EXACT
-#    This file must live at exactly: .github/workflows/ci.yml
-#    GitHub will silently ignore it if the folder name is wrong (e.g. .Github/,
-#    .github/workflow/, or .github/Workflows/).
-#
-# 6. STATUS CHECK NAME MUST MATCH BRANCH PROTECTION
-#    The job name below is "check". When you add a required status check in
-#    branch protection settings, search for "check" exactly — it must match
-#    the job: key in this file, not the workflow name: key at the top.
-#
-# 7. FIRST RUN MAY SHOW "EXPECTED — WAITING" IN BRANCH PROTECTION
-#    After adding a required status check, GitHub waits for the check to run
-#    at least once before enforcing it. Open a test PR to trigger the first run.
-#    Until then, the protection rule exists but is not yet blocking merges.
-#
-# 8. SECRETS AND TOKENS
-#    This workflow does not use any secrets. If you ever add a step that needs
-#    one (e.g. uploading an artifact, posting a comment), add it under:
-#    Settings → Secrets and variables → Actions → New repository secret
-#    Never hardcode tokens or passwords directly in this file.
-#
-# ─────────────────────────────────────────────────────────────────────────────
-
 name: CI
 
 on:
@@ -75,97 +6,63 @@ on:
       - dev
       - main
 
+env:
+  PART1_FILES: part1/gaussian.py part1/determinant.py part1/inverse.py part1/rank_basis.py
+  PART2_FILES: part2/decomposition.py part2/diagonalization.py part2/theme.py
+  PART3_FILES: part3/solvers.py part3/benchmark.py
+
 jobs:
+  # ── Fast gates: run first, fail before any install cost ─────────────────────
+  pre-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch name
+        if: github.event_name == 'pull_request' && github.head_ref != 'dev'
+        run: |
+          BRANCH="${{ github.head_ref }}"
+          if ! echo "$BRANCH" | grep -qE '^(feat|fix|docs|test|refactor|chore)/.+'; then
+            echo "::error::Branch '$BRANCH' must start with feat|fix|docs|test|refactor|chore/"
+            exit 1
+          fi
+
+  # ── Main quality checks ──────────────────────────────────────────────────────
   check:
     runs-on: ubuntu-latest
+    needs: pre-check
 
     steps:
-      # Step 1: Check out the branch being reviewed
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Step 2: Set up the Python version
-      # Pinned to 3.12 — stable, fast to provision, compatible with Manim 0.20.1
-      - name: Set up Python
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
-      # Step 3: Upgrade pip and install project dependencies
-      # Manim is excluded — it requires FFmpeg and Cairo which add 3-5 min to
-      # every CI run for no meaningful check. Syntax and lint cover what we need.
+      # Cache the pip install — skips re-downloading on unchanged requirements
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ runner.os }}-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: pip-${{ runner.os }}-
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install numpy scipy sympy matplotlib
-
-      # Step 4: Install flake8 separately so install failures are easy to isolate
-      - name: Install flake8
-        run: pip install flake8
-
-      # Step 5: Syntax check — catches import errors and broken files before review.
-      # Each file is only compiled if it exists; missing files are skipped gracefully.
-      - name: Check syntax — Part 1
-        run: |
-          for f in part1/gaussian.py part1/determinant.py part1/inverse.py part1/rank_basis.py; do
-            if [ -f "$f" ]; then
-              python -m py_compile "$f" && echo "OK: $f"
-            else
-              echo "Skipping $f (not found)"
-            fi
-          done
-
-      - name: Check syntax — Part 2
-        run: |
-          for f in part2/decomposition.py part2/diagonalization.py part2/theme.py; do
-            if [ -f "$f" ]; then
-              python -m py_compile "$f" && echo "OK: $f"
-            else
-              echo "Skipping $f (not found)"
-            fi
-          done
-
-      - name: Check syntax — Part 3 (bonus only)
-        run: |
-          for f in part3/solvers.py part3/benchmark.py; do
-            if [ -f "$f" ]; then
-              python -m py_compile "$f" && echo "OK: $f"
-            else
-              echo "Skipping $f (not found)"
-            fi
-          done
-
-      # Step 6: Lint with flake8
-      # --max-line-length=100   : allows slightly longer lines than PEP8's 79
-      # --ignore=E501           : don't double-flag long lines (max-line-length handles it)
-      # --ignore=W503           : line break before binary operator — stylistic, not an error
-      # --exclude=.venv         : never lint the virtual environment folder
-      # The directory is only linted if it exists; missing dirs are skipped gracefully.
-      - name: Lint with flake8
-        run: |
-          if [ -d "part1/" ]; then
-            flake8 part1/ \
-              --max-line-length=100 \
-              --ignore=E501,W503 \
-              --exclude=.venv
-          else
-            echo "Skipping lint — part1/ not found"
-          fi
+          pip install numpy scipy sympy matplotlib flake8 mypy
 
       - name: Check for banned solver calls
         run: |
-          # Build the list of directories that actually exist
-          dirs=""
-          for d in part1/ part2/ part3/; do
-            [ -d "$d" ] && dirs="$dirs $d"
+          files=""
+          for f in $PART1_FILES $PART2_FILES $PART3_FILES; do
+            [ -f "$f" ] && files="$files $f" || echo "Skipping $f (not found)"
           done
-
-          if [ -z "$dirs" ]; then
-            echo "No part directories found — skipping banned solver check"
+          if [ -z "$files" ]; then
+            echo "No files found — skipping banned solver check"
             exit 0
           fi
-
-          ! grep -rn \
+          ! grep -n \
             -e "linalg\.solve" \
             -e "linalg\.inv" \
             -e "scipy\.linalg\.qr" \
@@ -173,58 +70,45 @@ jobs:
             -e "\.rref()" \
             -e "\.echelon_form()" \
             -e "linsolve(" \
-            -e ".array" \
-            $dirs \
-            --include="*.py" \
-            --exclude="manim_scene.py"
+            -e "\.array" \
+            $files
 
-      - name: Install mypy
-        run: pip install mypy
+      # Single loop covers all parts — skips missing files gracefully
+      - name: Check syntax (all parts)
+        run: |
+          for f in $PART1_FILES $PART2_FILES $PART3_FILES; do
+            if [ -f "$f" ]; then
+              python -m py_compile "$f" && echo "OK: $f"
+            else
+              echo "Skipping $f (not found)"
+            fi
+          done
 
-      # Type-check steps collect only the files that actually exist, then run
-      # mypy once against all of them. The step is skipped entirely if none exist.
-      - name: Type check — Part 1
+      # Lint only the directories that exist
+      - name: Lint with flake8
+        run: |
+          dirs=""
+          for d in part1/ part2/ part3/; do
+            [ -d "$d" ] && dirs="$dirs $d"
+          done
+          if [ -n "$dirs" ]; then
+            flake8 $dirs \
+              --max-line-length=100 \
+              --ignore=E501,W503 \
+              --exclude=.venv
+          else
+            echo "No part directories found — skipping lint"
+          fi
+
+      # Single mypy call across all existing files — avoids 3 separate invocations
+      - name: Type check (all parts)
         run: |
           files=""
-          for f in part1/gaussian.py part1/determinant.py part1/inverse.py part1/rank_basis.py; do
+          for f in $PART1_FILES $PART2_FILES $PART3_FILES; do
             [ -f "$f" ] && files="$files $f" || echo "Skipping $f (not found)"
           done
           if [ -n "$files" ]; then
             mypy $files --config-file mypy.ini
           else
-            echo "No Part 1 files found — skipping type check"
-          fi
-
-      - name: Type check — Part 2
-        run: |
-          files=""
-          for f in part2/decomposition.py part2/diagonalization.py part2/theme.py; do
-            [ -f "$f" ] && files="$files $f" || echo "Skipping $f (not found)"
-          done
-          if [ -n "$files" ]; then
-            mypy $files --config-file mypy.ini
-          else
-            echo "No Part 2 files found — skipping type check"
-          fi
-
-      - name: Type check — Part 3
-        run: |
-          files=""
-          for f in part3/solvers.py part3/benchmark.py; do
-            [ -f "$f" ] && files="$files $f" || echo "Skipping $f (not found)"
-          done
-          if [ -n "$files" ]; then
-            mypy $files --config-file mypy.ini
-          else
-            echo "No Part 3 files found — skipping type check"
-          fi
-
-      - name: Check branch name
-        if: github.event_name == 'pull_request' && github.head_ref != 'dev'
-        run: |
-          BRANCH="${{ github.head_ref }}"
-          if ! echo "$BRANCH" | grep -qE '^(feat|fix|docs|test|refactor|chore)/.+'; then
-            echo "Branch name '$BRANCH' does not follow naming convention."
-            echo "Expected: feat/, fix/, docs/, test/, refactor/, or chore/"
-            exit 1
+            echo "No files found — skipping type check"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,9 @@ jobs:
     steps:
       - name: Check branch name
         if: github.event_name == 'pull_request' && github.head_ref != 'dev'
+        env:
+          BRANCH: ${{ github.head_ref }}
         run: |
-          BRANCH="${{ github.head_ref }}"
           if ! echo "$BRANCH" | grep -qE '^(feat|fix|docs|test|refactor|chore)/.+'; then
             echo "::error::Branch '$BRANCH' must start with feat|fix|docs|test|refactor|chore/"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: pip-${{ runner.os }}-${{ hashFiles('**/requirements*.txt') }}
+          key: pip-${{ runner.os }}-${{ hashFiles('.github/workflows/ci.yml') }}
           restore-keys: pip-${{ runner.os }}-
 
       - name: Install dependencies

--- a/part2/decomposition.py
+++ b/part2/decomposition.py
@@ -1,9 +1,10 @@
 from typing import List, Tuple
-from math import atan2, sin, cos, sqrt
+from math import atan2, sin, cos, sqrt, isnan
 
 
 def transpose(A: List[List[float]]) -> List[List[float]]:
     return [[A[j][i] for j in range(len(A))] for i in range(len(A[0]))]
+
 
 def multiply(A: List[List[float]], B: List[List[float]]) -> List[List[float]]:
     m, p = len(A), len(B[0])
@@ -15,10 +16,14 @@ def multiply(A: List[List[float]], B: List[List[float]]) -> List[List[float]]:
                 result[i][j] += A[i][k] * B[k][j]
     return result
 
+
 def get_identity_matrix(n: int) -> List[List[float]]:
     return [[1.0 if i == j else 0.0 for j in range(n)] for i in range(n)]
 
-def jacobi_eigenvalues(S: List[List[float]], error_tolerance: float = 1e-10, max_iterations: int = 100) -> Tuple[List[float], List[List[float]]]:
+
+def jacobi_eigenvalues(
+    S: List[List[float]], error_tolerance: float = 1e-10, max_iterations: int = 100
+) -> Tuple[List[float], List[List[float]]]:
     n = len(S)
 
     # V tích lũy các phép quay -> cuối cùng chứa vector riêng
@@ -49,8 +54,8 @@ def jacobi_eigenvalues(S: List[List[float]], error_tolerance: float = 1e-10, max
 
         s_pp, s_qq = S[p][p], S[q][q]
         # công thức biến đổi tương tự A' = J^T * A * J
-        S[p][p] = c ** 2 * s_pp - 2 * s * c * S[p][q] + s ** 2 * s_qq
-        S[q][q] = s ** 2 * s_pp + 2 * s * c * S[p][q] + c ** 2 * s_qq
+        S[p][p] = c**2 * s_pp - 2 * s * c * S[p][q] + s**2 * s_qq
+        S[q][q] = s**2 * s_pp + 2 * s * c * S[p][q] + c**2 * s_qq
         S[p][q] = S[q][p] = 0.0
 
         # cập nhật các hàng và cột p và q
@@ -60,22 +65,27 @@ def jacobi_eigenvalues(S: List[List[float]], error_tolerance: float = 1e-10, max
                 # áp dụng phép xoay lên các phần tử
                 S[i][p] = S[p][i] = c * s_ip - s * s_iq
                 S[i][q] = S[q][i] = s * s_ip + c * s_iq
-        
+
         # tích lũy phép quay
         for i in range(n):
             v_ip, v_iq = V[i][p], V[i][q]
             V[i][p] = c * v_ip - s * v_iq
             V[i][q] = s * v_ip + c * v_iq
-    
+
     if not is_converged:
-        raise ValueError(f"Numerical instability: Failed to converge within {max_iterations} iterations")
-    
+        raise ValueError(
+            f"Numerical instability: Failed to converge within {max_iterations} iterations"
+        )
+
     # sau khi hội tụ, ma trận S gần như chéo -> các phần tử nằm trên đường chéo là trị riêng
     eigenvalues = [S[i][i] for i in range(n)]
-    
+
     return eigenvalues, V
 
-def svd_decompose(A: List[List[float]], max_iterations: int = 100) -> Tuple[List[List[float]], List[List[float]], List[List[float]]]:
+
+def svd_decompose(
+    A: List[List[float]], max_iterations: int = 100
+) -> Tuple[List[List[float]], List[List[float]], List[List[float]]]:
     """
     Phân tách giá trị suy biến (Singular Value Decomposition - SVD) của một ma trận.
 
@@ -100,14 +110,14 @@ def svd_decompose(A: List[List[float]], max_iterations: int = 100) -> Tuple[List
         3. Tính các giá trị suy biến σ_i bằng cách lấy căn bậc hai λ_i. Xây dựng ma trận Σ.
         4. Tính ma trận U bằng công thức u_i = (1/σ_i) * A * v_i cho các σ_i > 0.
         5. Xử lý các trường hợp đặc biệt: ma trận chữ nhật (m != n) và ma trận thiếu hạng.
-    
+
     Độ phức tạp:
     - Phân tách: O(n^3) hoặc O(m * n^2) tùy thuộc thuật toán thực thi cụ thể.
     - Giải hệ: O(n^2) sau khi đã có dạng phân tách SVD.
     """
     if not A or not A[0]:
         raise ValueError("Input matrix is empty")
-    
+
     m = len(A)
     n = len(A[0])
 
@@ -120,14 +130,16 @@ def svd_decompose(A: List[List[float]], max_iterations: int = 100) -> Tuple[List
         lambdas, V = jacobi_eigenvalues(ATA, max_iterations)
     except ValueError as e:
         raise RuntimeError(f"SVD failed due to Jacobi eigenvalue error: {e}")
-    
-    # kiểm tra NaN
-    for l in lambdas:
-        if l != l:
-            raise ArithmeticError("Numerical instability: NaN values proceed during decomposition")
 
-    # tính các giá trị suy biến 
-    sigmas = [sqrt(max(0.0, l)) for l in lambdas]
+    # kiểm tra NaN
+    for _l in lambdas:
+        if isnan(_l):
+            raise ArithmeticError(
+                "Numerical instability: NaN values proceed during decomposition"
+            )
+
+    # tính các giá trị suy biến
+    sigmas = [sqrt(max(0.0, _l)) for _l in lambdas]
 
     # SVD cần có các giá trị suy biến sắp xếp theo thứ tự giảm dần
     indices = list(range(n))
@@ -170,7 +182,7 @@ def svd_decompose(A: List[List[float]], max_iterations: int = 100) -> Tuple[List
             product = sum(U[r][i] * U[r][j] for r in range(m))
             for r in range(m):
                 U[r][i] -= product * U[r][j]
-        
+
         # chuẩn hóa
         norm = sqrt(sum(U[r][i] ** 2 for r in range(m)))
         if norm > 1e-10:

--- a/part2/diagonalization.py
+++ b/part2/diagonalization.py
@@ -1,6 +1,9 @@
 from typing import List, Tuple
 
-def diagonalize(A: List[List[float]]) -> Tuple[List[List[float]], List[List[float]], List[List[float]]]:
+
+def diagonalize(
+    A: List[List[float]],
+) -> Tuple[List[List[float]], List[List[float]], List[List[float]]]:
     """
     Chéo hóa ma trận vuông A sao cho:
         A = P D P^-1
@@ -16,12 +19,13 @@ def diagonalize(A: List[List[float]]) -> Tuple[List[List[float]], List[List[floa
     (tương đương tổng bội hình học bằng kích thước ma trận).
 
     Giá trị trả về:
-        tuple: (P, D, P_inv) 
+        tuple: (P, D, P_inv)
     P: ma trận chứa các vector riêng dưới dạng các cột
     D: ma trận đường chéo chứa các giá trị riêng
     P_inv: ma trận nghịch đảo của P
     """
-    # Method: Sử dụng phương pháp lặp lũy thừa để tính toán giá trị riêng và vector riêng
+    # Method: Sử dụng phương pháp lặp lũy thừa để tính toán giá trị riêng
+    # và vector riêng
 
     # TODO:
     # - Kiểm tra A có phải ma trận vuông hay không
@@ -33,5 +37,5 @@ def diagonalize(A: List[List[float]]) -> Tuple[List[List[float]], List[List[floa
     P: List[List[float]] = [[]]
     D: List[List[float]] = [[]]
     P_inv: List[List[float]] = [[]]
-    
+
     return P, D, P_inv

--- a/part2/manim_scene.py
+++ b/part2/manim_scene.py
@@ -1,19 +1,57 @@
-from typing import Tuple, Sequence, List, cast
+from typing import Tuple, cast
 from manim import (
-    Scene, VGroup, Line, Circle, Vector, NumberPlane, 
-    DashedLine, Tex, MathTex, Arrow, Rectangle, 
-    ImageMobject, Axes, Dot, Ellipse, Text, Square, 
-    SurroundingRectangle, Create, FadeIn, FadeOut, 
-    ApplyMatrix, Rotate, ReplacementTransform, Indicate, 
-    interpolate_color, config, Write, Transform, VMobject, VGroup,
-    BLUE, GREEN, RED, WHITE, YELLOW, ORANGE, GREY, 
-    TAU, PI, ORIGIN, LEFT, RIGHT, UP, DOWN, UR
+    Scene,
+    Line,
+    Circle,
+    Vector,
+    NumberPlane,
+    DashedLine,
+    Tex,
+    MathTex,
+    Arrow,
+    Rectangle,
+    ImageMobject,
+    Axes,
+    Dot,
+    Ellipse,
+    Text,
+    Square,
+    SurroundingRectangle,
+    Create,
+    FadeIn,
+    FadeOut,
+    ApplyMatrix,
+    Rotate,
+    ReplacementTransform,
+    Indicate,
+    interpolate_color,
+    config,
+    Write,
+    Transform,
+    VMobject,
+    VGroup,
+    BLUE,
+    GREEN,
+    RED,
+    WHITE,
+    YELLOW,
+    ORANGE,
+    GREY,
+    TAU,
+    PI,
+    ORIGIN,
+    LEFT,
+    RIGHT,
+    UP,
+    DOWN,
+    UR,
 )
-from manim.utils.color import ManimColor, ParsableManimColor
+from manim.utils.color import ParsableManimColor
 import numpy as np
 
 config.media_width = "75%"
 config.verbosity = "WARNING"
+
 
 def create_gradient_circle(radius: float = 1.0, n_segments: int = 100) -> VGroup:
     segments = VGroup()
@@ -35,16 +73,13 @@ def create_gradient_circle(radius: float = 1.0, n_segments: int = 100) -> VGroup
 
     return segments
 
+
 class SVDIntro(Scene):
     def construct(self) -> None:
-        plane = NumberPlane(
-            background_line_style={
-                "stroke_opacity": 0.3
-            }
-        )
-        
+        plane = NumberPlane(background_line_style={"stroke_opacity": 0.3})
+
         circle = create_gradient_circle()
-        
+
         self.plane = plane
         self.circle = circle
 
@@ -73,22 +108,18 @@ class SVDIntro(Scene):
         self.play(FadeOut(v1, v2))
         self.play(FadeOut(plane), FadeOut(circle))
 
-        plane = NumberPlane(
-            background_line_style={
-                "stroke_opacity": 0.3
-            }
-        )
+        plane = NumberPlane(background_line_style={"stroke_opacity": 0.3})
         circle = Circle(color=BLUE)
 
         self.play(FadeIn(plane), FadeIn(circle))
-        
+
         # CUE 04
         target_axes = DashedLine(LEFT * 3, RIGHT * 3, color=WHITE)
         target_axes.set_opacity(0.5)
 
         self.play(Create(target_axes), run_time=1)
 
-        self.play(Rotate(VGroup(plane, circle), angle=PI/6), run_time=1.5)
+        self.play(Rotate(VGroup(plane, circle), angle=PI / 6), run_time=1.5)
         self.wait()
 
         # CUE 05
@@ -107,7 +138,7 @@ class SVDIntro(Scene):
         self.wait()
 
         # CUE 07
-        self.play(Rotate(circle, angle=-PI/8), run_time=1.5)
+        self.play(Rotate(circle, angle=-PI / 8), run_time=1.5)
 
         circle.set_color(GREEN)
         self.wait()
@@ -122,7 +153,9 @@ class SVDIntro(Scene):
         self.wait()
 
         # CUE 10
-        svd = MathTex("A = U \\Sigma V^T", substrings_to_isolate=["\\Sigma"]).to_corner(UR)
+        svd = MathTex("A = U \\Sigma V^T", substrings_to_isolate=["\\Sigma"]).to_corner(
+            UR
+        )
         svd.set_color_by_tex("\\Sigma", YELLOW)
 
         self.play(ReplacementTransform(pdp, svd), run_time=1.5)
@@ -140,34 +173,46 @@ class SVDIntro(Scene):
 
         # CUE 12
         self.play(
-            Indicate(ata, color=ORANGE),
-            Indicate(aat, color=ORANGE),
-            run_time=0.8
+            Indicate(ata, color=ORANGE), Indicate(aat, color=ORANGE), run_time=0.8
         )
         self.wait()
 
-def right_angle_marker(center: np.ndarray, size: float = 0.2, color: ParsableManimColor = WHITE) -> VGroup:
+
+def right_angle_marker(
+    center: np.ndarray, size: float = 0.2, color: ParsableManimColor = WHITE
+) -> VGroup:
     return VGroup(
         Line(center, center + RIGHT * size, color=color),
         Line(center + RIGHT * size, center + RIGHT * size + UP * size, color=color),
         Line(center + RIGHT * size + UP * size, center + UP * size, color=color),
     )
 
+
 class SVDComparisionScene(Scene):
     def construct(self) -> None:
         LEFT_POS = LEFT * 3.5
         RIGHT_POS = RIGHT * 3.5
 
-        plane_L = NumberPlane(
-            x_range=[-4, 4, 1],
-            y_range=[-4, 4, 1],
-            background_line_style={"stroke_opacity": 0.4}
-        ).scale(0.7).set_opacity(0.85).shift(LEFT_POS)
-        plane_R = NumberPlane(
-            x_range=[-4, 4, 1],
-            y_range=[-4, 4, 1],
-            background_line_style={"stroke_opacity": 0.4}
-        ).scale(0.7).set_opacity(0.85).shift(RIGHT_POS)
+        plane_L = (
+            NumberPlane(
+                x_range=[-4, 4, 1],
+                y_range=[-4, 4, 1],
+                background_line_style={"stroke_opacity": 0.4},
+            )
+            .scale(0.7)
+            .set_opacity(0.85)
+            .shift(LEFT_POS)
+        )
+        plane_R = (
+            NumberPlane(
+                x_range=[-4, 4, 1],
+                y_range=[-4, 4, 1],
+                background_line_style={"stroke_opacity": 0.4},
+            )
+            .scale(0.7)
+            .set_opacity(0.85)
+            .shift(RIGHT_POS)
+        )
 
         plane_L.set_color(BLUE)
         plane_R.set_color(GREEN)
@@ -176,11 +221,7 @@ class SVDComparisionScene(Scene):
         label_R = Tex("Output space ($U$)", color=GREEN).next_to(plane_R, UP)
 
         # CUE 13
-        self.play(
-            FadeIn(plane_L),
-            FadeIn(plane_R),
-            run_time=1.5
-        )
+        self.play(FadeIn(plane_L), FadeIn(plane_R), run_time=1.5)
         self.play(FadeIn(label_L), FadeIn(label_R), run_time=0.8)
         self.wait()
 
@@ -196,11 +237,7 @@ class SVDComparisionScene(Scene):
         v1_R = Vector(np.array([2, 0]), color=RED).shift(RIGHT_POS)
         v2_R = Vector(np.array([0, 2]), color=RED).shift(RIGHT_POS)
 
-        self.play(
-            Create(v1_L), Create(v2_L),
-            Create(v1_R), Create(v2_R),
-            run_time=0.8
-        )
+        self.play(Create(v1_L), Create(v2_L), Create(v1_R), Create(v2_R), run_time=0.8)
         self.wait()
 
         ghost_v1_L = v1_L.copy().set_opacity(0.5)
@@ -212,60 +249,39 @@ class SVDComparisionScene(Scene):
 
         # CUE 16
         self.play(
-            Rotate(
-                VGroup(v1_L, v2_L),
-                angle=PI / 2,
-                about_point=plane_L.get_center()
-            ),
-            run_time=1.5
+            Rotate(VGroup(v1_L, v2_L), angle=PI / 2, about_point=plane_L.get_center()),
+            run_time=1.5,
         )
 
         # CUE 17
-        right_group = VGroup(plane_R, v1_R, v2_R)
-
-        # self.play(
-        #     # VGroup(v1_R, v2_R).animate.apply_matrix(plane_R, rot, about_point=RIGHT_POS),
-        #     right_group.animate.rotate(90 * DEGREES, about_point=RIGHT_POS),
-        #     run_time=1.5
-        # )
-        # self.wait()
 
         self.play(
-            Rotate(
-                VGroup(v1_R, v2_R),
-                angle=PI / 2,
-                about_point=plane_R.get_center()
-            ),
-            run_time=1.5
+            Rotate(VGroup(v1_R, v2_R), angle=PI / 2, about_point=plane_R.get_center()),
+            run_time=1.5,
         )
 
         # CUE 18
-        svd = MathTex(
-            "A = U \\Sigma V^T",
-            substrings_to_isolate=["\\Sigma"]
-        ).to_edge(UP)
+        svd = MathTex("A = U \\Sigma V^T", substrings_to_isolate=["\\Sigma"]).to_edge(
+            UP
+        )
         svd.set_color_by_tex("\\Sigma", YELLOW)
 
         self.play(ReplacementTransform(pdp, svd), run_time=0.8)
         self.wait()
 
-        self.play(
-            FadeOut(v1_L), FadeOut(v2_L),
-            FadeOut(v1_R), FadeOut(v2_R)
-        )
+        self.play(FadeOut(v1_L), FadeOut(v2_L), FadeOut(v1_R), FadeOut(v2_R))
         self.wait()
 
         # CUE 19
         vectors_L = VGroup(
-            Vector(np.array([2, 0]), color=BLUE),
-            Vector(np.array([0, 2]), color=BLUE)
+            Vector(np.array([2, 0]), color=BLUE), Vector(np.array([0, 2]), color=BLUE)
         ).shift(plane_L.get_center())
-        
+
         v1_L, v2_L = vectors_L
 
         vectors_R = VGroup(
             Vector(np.array([1.5, 0]), color=GREEN),
-            Vector(np.array([0, 1]), color=GREEN)
+            Vector(np.array([0, 1]), color=GREEN),
         ).shift(plane_R.get_center())
 
         u1_R, u2_R = vectors_R
@@ -299,13 +315,17 @@ class SVDComparisionScene(Scene):
         self.play(
             Transform(
                 v1_L,
-                u1_R.copy().set_color(WHITE).shift(plane_L.get_center() - plane_R.get_center())
+                u1_R.copy()
+                .set_color(WHITE)
+                .shift(plane_L.get_center() - plane_R.get_center()),
             ),
             Transform(
                 v2_L,
-                u2_R.copy().set_color(WHITE).shift(plane_L.get_center() - plane_R.get_center())
+                u2_R.copy()
+                .set_color(WHITE)
+                .shift(plane_L.get_center() - plane_R.get_center()),
             ),
-            run_time=1.5
+            run_time=1.5,
         )
         self.wait()
 
@@ -314,7 +334,14 @@ class SVDComparisionScene(Scene):
         self.play(FadeIn(mn), run_time=0.8)
         self.wait()
 
-def create_tail_region(axes: Axes, k: float, x_max: float = 50, y_max: float = 5, color: ParsableManimColor = GREY) -> Rectangle:
+
+def create_tail_region(
+    axes: Axes,
+    k: float,
+    x_max: float = 50,
+    y_max: float = 5,
+    color: ParsableManimColor = GREY,
+) -> Rectangle:
     left = axes.c2p(k, 0)
     right = axes.c2p(x_max, y_max)
 
@@ -322,22 +349,17 @@ def create_tail_region(axes: Axes, k: float, x_max: float = 50, y_max: float = 5
     height = right[1] - left[1]
 
     rect = Rectangle(
-        width=width,
-        height=height,
-        fill_color=color,
-        fill_opacity=0.2,
-        stroke_width=0
+        width=width, height=height, fill_color=color, fill_opacity=0.2, stroke_width=0
     )
 
-    rect.move_to((
-        left[0] + width / 2,
-        left[1] + height / 2,
-        0
-    ))
+    rect.move_to((left[0] + width / 2, left[1] + height / 2, 0))
 
     return rect
 
-def compute_pca_arrows(dots: VGroup, scale1: float = 3, scale2: float = 2) -> Tuple[Arrow, Arrow, float, np.ndarray]:
+
+def compute_pca_arrows(
+    dots: VGroup, scale1: float = 3, scale2: float = 2
+) -> Tuple[Arrow, Arrow, float, np.ndarray]:
     points = np.array([dot.get_center()[:2] for dot in dots])
 
     mean = points.mean(axis=0)
@@ -354,7 +376,7 @@ def compute_pca_arrows(dots: VGroup, scale1: float = 3, scale2: float = 2) -> Tu
         color=YELLOW,
         buff=0,
         tip_length=0.15,
-        stroke_width=5
+        stroke_width=5,
     )
 
     pc2 = Arrow(
@@ -363,27 +385,24 @@ def compute_pca_arrows(dots: VGroup, scale1: float = 3, scale2: float = 2) -> Tu
         color=YELLOW,
         buff=0,
         tip_length=0.15,
-        stroke_width=5
+        stroke_width=5,
     )
 
     angle = np.float64(np.arctan2(pc1_direction[1], pc1_direction[0]))
 
     return pc1, pc2, angle, S
 
+
 class SVDApplicationScene(Scene):
     def construct(self) -> None:
         # CUE 24
         sigma_tex = r"\Sigma = \begin{bmatrix} 5 & 0 & 0 \\ 0 & 2 & 0 \\ 0 & 0 & 0.2 \end{bmatrix}"
-        sigma = MathTex(
-            sigma_tex,
-            substrings_to_isolate=["0.2"],
-            color=YELLOW
-        )
+        sigma = MathTex(sigma_tex, substrings_to_isolate=["0.2"], color=YELLOW)
         self.play(Write(sigma), run_time=2)
 
         small_value = sigma.get_part_by_tex("0.2")
 
-        if small_value != None:
+        if small_value is not None:
             self.play(small_value.animate.set_opacity(0.2), run_time=1)
         self.wait()
         self.play(FadeOut(sigma))
@@ -395,10 +414,14 @@ class SVDApplicationScene(Scene):
         self.wait()
 
         # CUE 26
-        axes = Axes(
-            x_range=[0, 50],
-            y_range=[0, 5],
-        ).scale(0.5).to_edge(RIGHT)
+        axes = (
+            Axes(
+                x_range=[0, 50],
+                y_range=[0, 5],
+            )
+            .scale(0.5)
+            .to_edge(RIGHT)
+        )
 
         graph = axes.plot(lambda x: 5 * np.exp(-0.1 * x), color=YELLOW)
 
@@ -420,38 +443,27 @@ class SVDApplicationScene(Scene):
         cut = DashedLine(axes.c2p(1, 0), axes.c2p(1, 5), color=ORANGE)
         tail = create_tail_region(axes, k=1)
 
-        self.play(
-            Create(cut),
-            Transform(img, k1),
-            FadeIn(tail),
-            run_time=1.5
-        )
+        self.play(Create(cut), Transform(img, k1), FadeIn(tail), run_time=1.5)
         self.wait(1)
 
         new_tail = create_tail_region(axes, k=10)
         self.play(
             Transform(tail, new_tail),
-            cut.animate.put_start_and_end_on(
-                axes.c2p(10, 0),
-                axes.c2p(10, 5)
-            ),
+            cut.animate.put_start_and_end_on(axes.c2p(10, 0), axes.c2p(10, 5)),
             Transform(img, k10),
-            run_time=1.8          
+            run_time=1.8,
         )
         self.wait(1)
 
         new_tail = create_tail_region(axes, k=50)
         self.play(
             Transform(tail, new_tail),
-            cut.animate.put_start_and_end_on(
-                axes.c2p(50, 0),
-                axes.c2p(50, 5)
-            ),
+            cut.animate.put_start_and_end_on(axes.c2p(50, 0), axes.c2p(50, 5)),
             Transform(img, k50),
-            run_time=1.2
+            run_time=1.2,
         )
         self.wait(1)
-        
+
         # CUE 29
         self.play(*[FadeOut(mob) for mob in self.mobjects])
         self.wait()
@@ -465,14 +477,16 @@ class SVDApplicationScene(Scene):
             x = rng.normal(scale=2.0)
             y = rng.normal(scale=0.5)
 
-            point = np.array([
-                x * np.cos(angle_val) - y * np.sin(angle_val),
-                x * np.sin(angle_val) + y * np.cos(angle_val),
-                0
-            ])
+            point = np.array(
+                [
+                    x * np.cos(angle_val) - y * np.sin(angle_val),
+                    x * np.sin(angle_val) + y * np.cos(angle_val),
+                    0,
+                ]
+            )
 
             dots.add(Dot(point, color=BLUE, radius=0.04))
-        
+
         self.play(FadeIn(dots), run_time=1.5)
         self.wait()
 
@@ -486,37 +500,30 @@ class SVDApplicationScene(Scene):
         group = VGroup(pc1, pc2)
 
         self.play(Create(group), run_time=1.5)
-        self.wait() 
+        self.wait()
 
         # CUE 32
-        ellipse = Ellipse(
-            width=5,
-            height=1.5,
-            color=ORANGE,
-            stroke_width=4
-        )
+        ellipse = Ellipse(width=5, height=1.5, color=ORANGE, stroke_width=4)
 
         ellipse.rotate(final_angle)
         ellipse.move_to(center)
 
-        self.play(
-            dots.animate.set_opacity(0.75),
-            FadeIn(ellipse),
-            run_time=1.5
-        )
+        self.play(dots.animate.set_opacity(0.75), FadeIn(ellipse), run_time=1.5)
         self.wait()
 
         self.play(*[FadeOut(mob) for mob in self.mobjects])
         self.wait(1)
 
         # CUE 33
-        data = np.array([
-            [5, 4, 0, 0],
-            [3, 5, 0, 0],
-            [4, 4, 1, 0],
-            [0, 0, 3, 5],
-            [0, 0, 4, 4],
-        ])
+        data = np.array(
+            [
+                [5, 4, 0, 0],
+                [3, 5, 0, 0],
+                [4, 4, 1, 0],
+                [0, 0, 3, 5],
+                [0, 0, 4, 4],
+            ]
+        )
 
         max_val = data.max()
         grid = VGroup()
@@ -530,19 +537,23 @@ class SVDApplicationScene(Scene):
                 cell.set_stroke(width=0)
                 cell.move_to(RIGHT * j * 0.6 + DOWN * i * 0.6)
                 grid.add(cell)
-        
+
         grid.move_to(ORIGIN)
         words = ["marathon", "sprint", "run", "feline", "cat"]
-        row_labels = VGroup(*[
-            Text(word, font_size=24).next_to(grid[i * cols], LEFT, buff=0.3)
-            for i, word in enumerate(words)
-        ])
+        row_labels = VGroup(
+            *[
+                Text(word, font_size=24).next_to(grid[i * cols], LEFT, buff=0.3)
+                for i, word in enumerate(words)
+            ]
+        )
 
         docs = ["D1", "D2", "D3", "D4"]
-        col_labels = VGroup(*[
-            Text(doc, font_size=24).next_to(grid[j], UP, buff=0.3)
-            for j, doc in enumerate(docs)
-        ])
+        col_labels = VGroup(
+            *[
+                Text(doc, font_size=24).next_to(grid[j], UP, buff=0.3)
+                for j, doc in enumerate(docs)
+            ]
+        )
 
         self.play(Create(grid), FadeIn(row_labels), FadeIn(col_labels), run_time=1.5)
         self.wait()
@@ -557,13 +568,15 @@ class SVDApplicationScene(Scene):
         self.wait()
 
         # CUE 35
-        smooth_data = np.array([
-            [5, 4, 0, 0],
-            [4, 5, 0, 0],
-            [4, 4, 1, 0],
-            [0, 0, 4, 5],
-            [0, 0, 5, 4],
-        ])
+        smooth_data = np.array(
+            [
+                [5, 4, 0, 0],
+                [4, 5, 0, 0],
+                [4, 4, 1, 0],
+                [0, 0, 4, 5],
+                [0, 0, 5, 4],
+            ]
+        )
 
         max_val_smooth = smooth_data.max()
         smooth_grid = VGroup()
@@ -586,13 +599,11 @@ class SVDApplicationScene(Scene):
         # CUE 36
         self.play(FadeIn(row_labels), FadeIn(col_labels), run_time=1)
 
-        running_group = VGroup(*[
-            cast(VMobject, smooth_grid[i]) for i in [0, 1, 4, 5, 8, 9]
-        ])
+        running_group = VGroup(
+            *[cast(VMobject, smooth_grid[i]) for i in [0, 1, 4, 5, 8, 9]]
+        )
 
-        cat_group = VGroup(*[
-            cast(VMobject, smooth_grid[i]) for i in [14, 15, 18, 19]
-        ])
+        cat_group = VGroup(*[cast(VMobject, smooth_grid[i]) for i in [14, 15, 18, 19]])
 
         highlight1 = SurroundingRectangle(running_group, color=ORANGE, stroke_width=3)
         highlight2 = SurroundingRectangle(cat_group, color=ORANGE, stroke_width=3)

--- a/part2/theme.py
+++ b/part2/theme.py
@@ -1,18 +1,19 @@
 # pip install manim-fonts
-from manim import Scene, Matrix, Text, Color # type: ignore
+from manim import Scene, Matrix, Text
 from typing import List, Any
 
 # Palette
-BG        = '#F5F4EF'   # warm off-white
-TEXT      = '#1A1A2E'   # near-black navy, not pure black
-ACCENT    = '#2E7D6B'   # deep teal — primary highlight
-ACCENT2   = '#C97B2A'   # warm amber — secondary, used sparingly
-MUTED     = '#6B6B6B'   # gray for labels and annotations
-HIGHLIGHT = '#E8F4F1'   # very light teal for background fills
+BG = "#F5F4EF"  # warm off-white
+TEXT = "#1A1A2E"  # near-black navy, not pure black
+ACCENT = "#2E7D6B"  # deep teal — primary highlight
+ACCENT2 = "#C97B2A"  # warm amber — secondary, used sparingly
+MUTED = "#6B6B6B"  # gray for labels and annotations
+HIGHLIGHT = "#E8F4F1"  # very light teal for background fills
+
 
 class ProjectScene(Scene):
     def setup(self) -> None:
-        self.camera.background_color = BG # type: ignore
+        self.camera.background_color = BG  # type: ignore
 
     def make_matrix(self, data: List[List[Any]], color: str = TEXT) -> Matrix:
         m = Matrix(data)
@@ -20,9 +21,7 @@ class ProjectScene(Scene):
         return m
 
     def accent_text(self, text: str, scale: float = 1.0) -> Text:
-        return Text(text, font='IBM Plex Sans',
-                    color=ACCENT).scale(scale)
+        return Text(text, font="IBM Plex Sans", color=ACCENT).scale(scale)
 
     def body_text(self, text: str, scale: float = 0.7) -> Text:
-        return Text(text, font='IBM Plex Sans',
-                    color=TEXT).scale(scale)
+        return Text(text, font="IBM Plex Sans", color=TEXT).scale(scale)


### PR DESCRIPTION
Optimize CI for faster checking time.

* Cache pip dependencies — biggest win, saves 30–60s per run
* Parallelize with a matrix or separate jobs where possible
* Combine the repetitive syntax/type-check loops into single steps
* Fail fast — move cheap checks (branch name, banned solvers) earlier
* Deduplicate the file lists into a single `env` var
* Banned solvers check now check only targeted files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI optimized: added a pre-check for branch names, unified/install dependencies in one step, added pip caching, and consolidated file-list driven syntax and type checks.

* **Style**
  * Added Flake8 config (max line length 120, E203 ignored); linting now targets existing part directories.

* **Refactor**
  * Formatting and code cleanups across modules plus a minor correctness tweak in numeric handling; no public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->